### PR TITLE
ci: Change test image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
     name: Shopware ${{ matrix.shopware-version }}
 
     container:
-      image: ghcr.io/friendsofshopware/platform-plugin-dev:${{ matrix.shopware-version }}-bullseye
+      image: ghcr.io/friendsofshopware/platform-plugin-dev:${{ matrix.shopware-version }}-debian
     env:
       PLUGIN_DIR: /plugins/EasyCreditRatenkauf
       SW_DIR: /opt/shopware


### PR DESCRIPTION
Since the `bullseye` images have been renamed to `debian`, since for Shopware 6.6 it will be bookwork due to the required PHP8.3 version.