### PR TITLE
remove duplicate main.js to prevent duplicate building

### DIFF
--- a/src/Resources/views/storefront/main.js
+++ b/src/Resources/views/storefront/main.js
@@ -1,3 +1,0 @@
-// Import all necessary Storefront plugins and scss files
-
-// Register them via the existing PluginManager


### PR DESCRIPTION
When rebuilding using `./bin/build-storefront.sh` storefront two packages were built which led to the js error 'Plugin "easyCreditCheckoutRatenkauf" is already registered. ".